### PR TITLE
Fix refund failure messages

### DIFF
--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -47,7 +47,7 @@ class RefundRequest extends AbstractRequest
             // On HTTP errors being returned, we still want to pass the response through, as Verifone passes through extra data in the body of errors,
             //  but only if it's returning json with a message field.
             $response = $e->getResponse();
-            $data = json_decode($response);
+            $data = json_decode($response->getBody(true), true);
             if(!empty($data["message"])){
                 $httpResponse = $response;
             }else{

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -2,9 +2,7 @@
 
 namespace DigiTickets\OmnipayVerifoneCheckout\Message;
 
-use DigiTickets\Funcs\Strings;
 use Guzzle\Http\Exception\BadResponseException;
-use Guzzle\Http\Message\Response;
 
 class RefundRequest extends AbstractRequest
 {

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -2,6 +2,10 @@
 
 namespace DigiTickets\OmnipayVerifoneCheckout\Message;
 
+use DigiTickets\Funcs\Strings;
+use Guzzle\Http\Exception\BadResponseException;
+use Guzzle\Http\Message\Response;
+
 class RefundRequest extends AbstractRequest
 {
     const REFUND_ACTION_REFUND = 'refund';
@@ -28,15 +32,29 @@ class RefundRequest extends AbstractRequest
     {
         $transactionRef = $this->getTransactionReference();
 
-        //get the transaction using the verifone API
-        $httpResponse = $this->httpClient->post(
-            $this->getEndpoint().'/transaction/'.$transactionRef.'/'.$this->getRefundAction(),
-            [
-                'X-APIKEY' => $this->getApiKey(),
-                'Content-Type' => 'application/json',
-            ],
-            json_encode($data)
-        )->send();
+        // Refund or void the transaction using the verifone API
+        try{
+            $httpResponse = $this->httpClient->post(
+                $this->getEndpoint().'/transaction/'.$transactionRef.'/'.$this->getRefundAction(),
+                [
+                    'X-APIKEY' => $this->getApiKey(),
+                    'Content-Type' => 'application/json',
+                ],
+                json_encode($data)
+            )->send();
+
+        } catch (BadResponseException $e) {
+            // On HTTP errors being returned, we still want to pass the response through, as Verifone passes through extra data in the body of errors,
+            //  but only if it's returning json with a message field.
+            $response = $e->getResponse();
+            $data = json_decode($response);
+            if(!empty($data["message"])){
+                $httpResponse = $response;
+            }else{
+                // Unknown error
+                throw $e;
+            }
+        }
 
         return $this->response = new RefundResponse($this, $httpResponse->json());
     }

--- a/src/Message/RefundResponse.php
+++ b/src/Message/RefundResponse.php
@@ -32,14 +32,16 @@ class RefundResponse extends AbstractResponse
      */
     public function getMessage()
     {
+        $output = [
+            $this->data['status'] ?? '',
+            $this->data['status_reason'] ?? '',
+            // This is only filled when there is an http error
+            $this->data['message'] ?? '',
+        ];
+
         return implode(
             ' - ',
-            array_filter(
-                [
-                    $this->data['status'] ?? '',
-                    $this->data['status_reason'] ?? '',
-                ]
-            )
+            array_filter($output)
         );
     }
 
@@ -48,6 +50,6 @@ class RefundResponse extends AbstractResponse
      */
     public function getCode()
     {
-        return $this->data['status'] ?? '';
+        return $this->data['status'] ?? $this->data['code'] ?? '';
     }
 }

--- a/tests/RefundResponseTest.php
+++ b/tests/RefundResponseTest.php
@@ -45,6 +45,12 @@ class RefundResponseTest extends TestCase
                 'FAILED - failed reason',
                 '123',
             ],
+            'http error' => [
+                ['_id' => '123', 'message' => 'Bad request', 'code' => '400'],
+                false,
+                'Bad request',
+                '123',
+            ],
         ];
     }
 }


### PR DESCRIPTION
Verifone causes http exceptions when certain issues happen (e.g. invalid params will return an http 400). Pick these up and attempt to parse the body for useful error messages.
Response format is here: https://verifone.cloud/api-catalog/verifone-ecommerce-api#operation/refundPayment

BAC-6714